### PR TITLE
Fix Celery integration, restore validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@
    ```bash
    uvicorn app:app --reload
    ```
+3. Start a Celery worker (requires a Redis server):
+   ```bash
+   CELERY_BROKER_URL=redis://localhost:6379/0 celery -A tasks worker --loglevel=info
+   ```
 
 
 ## Configuration

--- a/app.py
+++ b/app.py
@@ -7,6 +7,12 @@ from typing import List
 from fastapi import FastAPI, UploadFile, File, Request, HTTPException
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
+from fastapi.concurrency import run_in_threadpool
+
+# Import celery_app so a worker can load the tasks module
+from tasks import store_file, celery_app
+
+__all__ = ["celery_app"]
 
 app = FastAPI()
 
@@ -15,6 +21,8 @@ templates = Jinja2Templates(directory=TEMPLATES_DIR)
 
 DEFAULT_DB_PATH = os.path.join(os.path.dirname(__file__), "data", "database.db")
 DB_PATH = os.getenv("DB_PATH", DEFAULT_DB_PATH)
+
+MAX_FILE_SIZE = 16 * 1024 * 1024  # 16 MB
 
 
 def init_db() -> None:
@@ -63,27 +71,30 @@ async def read_root(request: Request):
 
 @app.post("/upload")
 async def upload_files(files: List[UploadFile] = File(...)):
-    """Accept PDF and CSV files and store their contents."""
-    records = []
+    """Accept PDF and CSV files and delegate storage to a Celery task."""
+    allowed_types = {"application/pdf", "text/csv"}
     for file in files:
         if not (
             file.filename.lower().endswith(".pdf")
             or file.filename.lower().endswith(".csv")
         ):
             raise HTTPException(status_code=400, detail="Invalid file type")
+        if file.content_type not in allowed_types:
+            raise HTTPException(status_code=400, detail="Invalid MIME type")
         content = await file.read()
-        records.append((file.filename, sqlite3.Binary(content)))
-    with sqlite3.connect(DB_PATH) as conn:
-        conn.executemany(
-            "INSERT INTO files(filename, content) VALUES (?, ?)",
-            records,
-        )
+        if len(content) > MAX_FILE_SIZE:
+            raise HTTPException(status_code=400, detail="File too large")
+        store_file.delay(file.filename, content)
     return {"filenames": [file.filename for file in files]}
 
 
 @app.post("/purge")
 async def purge_database():
     """Remove all uploaded file records."""
-    with sqlite3.connect(DB_PATH) as conn:
-        conn.execute("DELETE FROM files")
+
+    def purge() -> None:
+        with sqlite3.connect(DB_PATH) as conn:
+            conn.execute("DELETE FROM files")
+
+    await run_in_threadpool(purge)
     return {"status": "purged"}

--- a/decisions/celery_background_tasks_adr.md
+++ b/decisions/celery_background_tasks_adr.md
@@ -1,0 +1,14 @@
+# ADR: Use Celery with Redis for Background Tasks
+
+## Context
+Large file uploads can slow down HTTP responses if processed synchronously. We need an asynchronous
+worker to handle storing files outside the FastAPI request cycle.
+
+## Decision
+Integrate [Celery](https://docs.celeryq.dev/en/stable/getting-started/first-steps-with-celery.html)
+with a Redis broker. The `/upload` endpoint will queue a `store_file` task that writes the bytes to
+SQLite. Tests run Celery in eager mode to avoid requiring a broker during CI.
+
+## Links
+- <https://docs.celeryq.dev/en/stable/getting-started/first-steps-with-celery.html>
+- <https://testdriven.io/blog/fastapi-celery/>

--- a/logs/actions.jsonl
+++ b/logs/actions.jsonl
@@ -25,3 +25,6 @@
 {"timestamp": "2025-07-15T22:30:41Z", "action": "Store uploads as BLOBs, update code, tests, docs, ADR", "ticket_id": "task-store-uploads-blob"}
 
 {"timestamp": "2025-07-15T22:47:23Z", "action": "Include tests in Docker image and update CI docs", "ticket_id": "task-docker-tests-fix"}
+{"timestamp": "2025-07-15T23:57:33Z", "action": "Add Celery background processing with Redis, update docs and tests", "ticket_id": "task-celery-bg"}
+{"timestamp": "2025-07-16T00:13:08Z", "action": "Fix formatting issues in app.py and ensure lint/tests pass", "ticket_id": "task-celery-bg-format-fix"}
+{"timestamp": "2025-07-16T00:19:44Z", "action": "Restore validation logic with Celery, run in threadpool for purge", "ticket_id": "task-celery-bg-fixes"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ black
 pylint
 python-multipart
 beautifulsoup4
+celery
+redis

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,40 @@
+"""Celery tasks for background file processing."""
+
+import os
+import sqlite3
+from celery import Celery
+
+DEFAULT_DB_PATH = os.path.join(os.path.dirname(__file__), "data", "database.db")
+DB_PATH = os.getenv("DB_PATH", DEFAULT_DB_PATH)
+
+CELERY_BROKER_URL = os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
+celery_app = Celery("smartbooks", broker=CELERY_BROKER_URL)
+
+if os.getenv("CELERY_TASK_ALWAYS_EAGER"):
+    celery_app.conf.task_always_eager = True
+
+
+def init_db() -> None:
+    """Create the files table if needed."""
+    os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            (
+                "CREATE TABLE IF NOT EXISTS files ("
+                "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                "filename TEXT, content BLOB)"
+            )
+        )
+
+
+init_db()
+
+
+@celery_app.task
+def store_file(filename: str, content: bytes) -> None:
+    """Persist an uploaded file to the SQLite database."""
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            "INSERT INTO files(filename, content) VALUES (?, ?)",
+            (filename, sqlite3.Binary(content)),
+        )


### PR DESCRIPTION
## Summary
- restore file type checks and size limit in `/upload`
- run `/purge` database cleanup in a threadpool
- add tests for invalid MIME type and file size
- log the fix in `actions.jsonl`

## Testing
- `black --check .`
- `pylint app.py tasks.py tests/test_app.py tests/test_dockerignore.py tests/test_template.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6876e48db224832bbd5eb32813c3cd7a