### PR TITLE
Implement DB path dependency injection

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,9 +4,10 @@ import os
 import sqlite3
 from typing import List
 
-from fastapi import FastAPI, UploadFile, File, Request, HTTPException
+from fastapi import FastAPI, UploadFile, File, Request, HTTPException, Depends
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
+from fastapi.concurrency import run_in_threadpool
 
 app = FastAPI()
 
@@ -14,13 +15,15 @@ TEMPLATES_DIR = os.path.join(os.path.dirname(__file__), "templates")
 templates = Jinja2Templates(directory=TEMPLATES_DIR)
 
 DEFAULT_DB_PATH = os.path.join(os.path.dirname(__file__), "data", "database.db")
-DB_PATH = os.getenv("DB_PATH", DEFAULT_DB_PATH)
+app.state.db_path = os.getenv("DB_PATH", DEFAULT_DB_PATH)
+
+MAX_FILE_SIZE = 16 * 1024 * 1024  # 16 MB
 
 
-def init_db() -> None:
+def init_db(db_path: str) -> None:
     """Create the files table if it doesn't exist and ensure `content` column."""
-    os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
-    with sqlite3.connect(DB_PATH) as conn:
+    os.makedirs(os.path.dirname(db_path), exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
         conn.execute(
             (
                 "CREATE TABLE IF NOT EXISTS files ("
@@ -33,7 +36,12 @@ def init_db() -> None:
             conn.execute("ALTER TABLE files ADD COLUMN content BLOB")
 
 
-init_db()
+init_db(app.state.db_path)
+
+
+def get_db_path() -> str:
+    """Return the configured database path."""
+    return app.state.db_path
 
 
 DEFAULT_CONTEXT = {
@@ -62,8 +70,11 @@ async def read_root(request: Request):
 
 
 @app.post("/upload")
-async def upload_files(files: List[UploadFile] = File(...)):
+async def upload_files(
+    files: List[UploadFile] = File(...), db_path: str = Depends(get_db_path)
+):
     """Accept PDF and CSV files and store their contents."""
+    allowed_types = {"application/pdf", "text/csv"}
     records = []
     for file in files:
         if not (
@@ -71,19 +82,31 @@ async def upload_files(files: List[UploadFile] = File(...)):
             or file.filename.lower().endswith(".csv")
         ):
             raise HTTPException(status_code=400, detail="Invalid file type")
+        if file.content_type not in allowed_types:
+            raise HTTPException(status_code=400, detail="Invalid MIME type")
         content = await file.read()
+        if len(content) > MAX_FILE_SIZE:
+            raise HTTPException(status_code=400, detail="File too large")
         records.append((file.filename, sqlite3.Binary(content)))
-    with sqlite3.connect(DB_PATH) as conn:
-        conn.executemany(
-            "INSERT INTO files(filename, content) VALUES (?, ?)",
-            records,
-        )
+
+    def insert_records() -> None:
+        with sqlite3.connect(db_path) as conn:
+            conn.executemany(
+                "INSERT INTO files(filename, content) VALUES (?, ?)",
+                records,
+            )
+
+    await run_in_threadpool(insert_records)
     return {"filenames": [file.filename for file in files]}
 
 
 @app.post("/purge")
-async def purge_database():
+async def purge_database(db_path: str = Depends(get_db_path)):
     """Remove all uploaded file records."""
-    with sqlite3.connect(DB_PATH) as conn:
-        conn.execute("DELETE FROM files")
+
+    def purge() -> None:
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("DELETE FROM files")
+
+    await run_in_threadpool(purge)
     return {"status": "purged"}

--- a/decisions/db_path_dependency_injection_adr.md
+++ b/decisions/db_path_dependency_injection_adr.md
@@ -1,0 +1,13 @@
+# ADR: Inject database path via FastAPI dependency
+
+## Context
+The application used a module-level `DB_PATH` constant, requiring module reloads in tests to use a temporary database. This made tests slower and harder to maintain.
+
+## Decision
+Implement a `get_db_path` dependency returning `app.state.db_path`. Each route receives `db_path: str = Depends(get_db_path)` and `init_db` accepts the path as a parameter. Tests override `get_db_path` to point to a temporary file, avoiding module reloads.
+Database writes are executed using `run_in_threadpool` from `fastapi.concurrency` to keep the event loop responsive.
+
+## Links
+- https://fastapi.tiangolo.com/tutorial/dependencies/
+- https://docs.pytest.org/en/latest/how-to/tmp_path.html
+- https://fastapi.tiangolo.com/advanced/asyncio/#run-in-threadpool

--- a/logs/actions.jsonl
+++ b/logs/actions.jsonl
@@ -25,3 +25,8 @@
 {"timestamp": "2025-07-15T22:30:41Z", "action": "Store uploads as BLOBs, update code, tests, docs, ADR", "ticket_id": "task-store-uploads-blob"}
 
 {"timestamp": "2025-07-15T22:47:23Z", "action": "Include tests in Docker image and update CI docs", "ticket_id": "task-docker-tests-fix"}
+{"timestamp": "2025-07-15T23:58:29Z", "action": "Add dependency injection for DB path, update tests and ADR", "ticket_id": "task-dependency-injection"}
+{"timestamp": "2025-07-16T00:11:40.563881Z", "action": "Fix DB path injection conflicts, restore async DB operations", "ticket_id": "task-dependency-injection-fix"}
+{"timestamp": "2025-07-16T00:15:44Z", "action": "Switch run_in_threadpool import to fastapi module and update ADR", "ticket_id": "task-dependency-injection-fix2"}
+{"timestamp": "2025-07-16T00:20:28Z", "action": "Finalize DB path injection and update tests", "ticket_id": "task-dependency-injection-final"}
+{"timestamp": "2025-07-16T03:09:40Z", "action": "Restore missing tests for DB path injection and MIME/size checks", "ticket_id": "task-dependency-injection-cleanup"}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,23 +1,35 @@
 """Tests for app module."""
 
-# pylint: disable=wrong-import-position, import-outside-toplevel
+# pylint: disable=wrong-import-position, import-outside-toplevel, redefined-outer-name
 
 from pathlib import Path
 import sqlite3
 import sys
+import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
+from fastapi.concurrency import run_in_threadpool
 from fastapi.testclient import TestClient
 from bs4 import BeautifulSoup
-from app import app, DB_PATH
-
-client = TestClient(app)
+from app import app, get_db_path, init_db
 
 
-def test_get_root():
+@pytest.fixture
+def client_fixture(tmp_path):
+    """Return TestClient with temporary database."""
+    db_path = tmp_path / "test.db"
+    init_db(str(db_path))
+    app.dependency_overrides[get_db_path] = lambda: str(db_path)
+    test_client = TestClient(app)
+    yield test_client, db_path
+    app.dependency_overrides.clear()
+
+
+def test_get_root(client_fixture):
     """Home page should render successfully and contain the heading."""
-    response = client.get("/")
+    test_client, _ = client_fixture
+    response = test_client.get("/")
     assert response.status_code == 200
     soup = BeautifulSoup(response.text, "html.parser")
     h1 = soup.find("h1", class_="display-4")
@@ -25,16 +37,17 @@ def test_get_root():
     assert h1.text.strip() == "smartBooks"
 
 
-def test_upload_valid_file(tmp_path):
+def test_upload_valid_file(client_fixture, tmp_path):
     """Uploading a valid PDF should succeed."""
     pdf_file = tmp_path / "test.pdf"
     pdf_file.write_bytes(b"%PDF-1.4")
+    test_client, db_path = client_fixture
     with pdf_file.open("rb") as f:
         files = {"files": ("test.pdf", f, "application/pdf")}
-        response = client.post("/upload", files=files)
+        response = test_client.post("/upload", files=files)
     assert response.status_code == 200
     assert response.json() == {"filenames": ["test.pdf"]}
-    with sqlite3.connect(DB_PATH) as conn:
+    with sqlite3.connect(db_path) as conn:
         cur = conn.execute(
             "SELECT filename, content FROM files WHERE filename=?", ("test.pdf",)
         )
@@ -42,65 +55,117 @@ def test_upload_valid_file(tmp_path):
     assert row == ("test.pdf", b"%PDF-1.4")
 
 
-def test_upload_invalid_file(tmp_path):
+def test_upload_invalid_file(client_fixture, tmp_path):
     """Uploading a non PDF/CSV should fail."""
     txt_file = tmp_path / "test.txt"
     txt_file.write_text("dummy")
+    test_client, _ = client_fixture
     with txt_file.open("rb") as f:
         files = {"files": ("test.txt", f, "text/plain")}
-        response = client.post("/upload", files=files)
+        response = test_client.post("/upload", files=files)
     assert response.status_code == 400
 
 
-def count_files():
+def test_upload_invalid_mime_type(client_fixture, tmp_path):
+    """Uploading with valid extension but wrong MIME type should fail."""
+    pdf_file = tmp_path / "fake.pdf"
+    pdf_file.write_bytes(b"%PDF-1.4")
+    test_client, _ = client_fixture
+    with pdf_file.open("rb") as f:
+        files = {"files": ("fake.pdf", f, "text/plain")}
+        response = test_client.post("/upload", files=files)
+    assert response.status_code == 400
+
+
+def test_upload_too_large(client_fixture, tmp_path):
+    """Files larger than the 16 MB limit should be rejected."""
+    big_file = tmp_path / "big.pdf"
+    big_file.write_bytes(b"0" * (16 * 1024 * 1024 + 1))
+    test_client, _ = client_fixture
+    with big_file.open("rb") as f:
+        files = {"files": ("big.pdf", f, "application/pdf")}
+        response = test_client.post("/upload", files=files)
+    assert response.status_code == 400
+
+
+def count_files(db_path: str) -> int:
     """Return number of stored file records."""
-    with sqlite3.connect(DB_PATH) as conn:
+    with sqlite3.connect(db_path) as conn:
         cur = conn.execute("SELECT COUNT(*) FROM files")
         return cur.fetchone()[0]
 
 
-def test_purge_endpoint(tmp_path):
+def test_purge_endpoint(client_fixture, tmp_path):
     """Uploaded files should be removed by the purge endpoint."""
     pdf = tmp_path / "purge.pdf"
     pdf.write_bytes(b"%PDF-1.4")
+    test_client, db_path = client_fixture
     with pdf.open("rb") as f:
-        response = client.post(
+        response = test_client.post(
             "/upload", files={"files": ("purge.pdf", f, "application/pdf")}
         )
     assert response.status_code == 200
-    assert count_files() > 0
-    with sqlite3.connect(DB_PATH) as conn:
+    assert count_files(db_path) > 0
+    with sqlite3.connect(db_path) as conn:
         cur = conn.execute(
             "SELECT filename, content FROM files WHERE filename=?", ("purge.pdf",)
         )
         row = cur.fetchone()
     assert row == ("purge.pdf", b"%PDF-1.4")
 
-    response = client.post("/purge")
+    response = test_client.post("/purge")
     assert response.status_code == 200
     assert response.json() == {"status": "purged"}
-    assert count_files() == 0
+    assert count_files(db_path) == 0
 
 
-def test_env_db_path(tmp_path, monkeypatch):
-    """Setting DB_PATH should create database at the custom location."""
+def test_upload_uses_threadpool(client_fixture, tmp_path, monkeypatch):
+    """upload_files should call run_in_threadpool for DB writes."""
+    pdf = tmp_path / "thread.pdf"
+    pdf.write_bytes(b"%PDF-1.4")
+    test_client, _ = client_fixture
+    with pdf.open("rb") as f:
+        files = {"files": ("thread.pdf", f, "application/pdf")}
+        with monkeypatch.context() as m:
+            called = False
+
+            async def wrapper(func, *args, **kwargs):
+                nonlocal called
+                called = True
+                return await run_in_threadpool(func, *args, **kwargs)
+
+            m.setattr("app.run_in_threadpool", wrapper)
+            response = test_client.post("/upload", files=files)
+    assert response.status_code == 200
+    assert called
+
+
+def test_purge_uses_threadpool(client_fixture, monkeypatch):
+    """purge_database should call run_in_threadpool."""
+    test_client, _ = client_fixture
+    with monkeypatch.context() as m:
+        called = False
+
+        async def wrapper(func, *args, **kwargs):
+            nonlocal called
+            called = True
+            return await run_in_threadpool(func, *args, **kwargs)
+
+        m.setattr("app.run_in_threadpool", wrapper)
+        response = test_client.post("/purge")
+    assert response.status_code == 200
+    assert called
+
+
+def test_override_db_path(tmp_path):
+    """Dependency override should store data at the provided path."""
     custom_path = tmp_path / "custom.db"
-    monkeypatch.setenv("DB_PATH", str(custom_path))
-    import importlib
-    import app as app_module
-
-    importlib.reload(app_module)
-    client_env = TestClient(app_module.app)
+    app.dependency_overrides[get_db_path] = lambda: str(custom_path)
+    init_db(str(custom_path))
+    client_env = TestClient(app)
 
     response = client_env.get("/")
     assert response.status_code == 200
     assert custom_path.exists()
 
-    monkeypatch.delenv("DB_PATH", raising=False)
-    importlib.reload(app_module)
-
-    with sqlite3.connect(DB_PATH) as conn:
-        cur = conn.execute(
-            "SELECT filename FROM files WHERE filename=?", ("purge.pdf",)
-        )
-        assert cur.fetchone() is None
+    app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- inject database path via FastAPI dependency for easier testing
- restore MIME type and size validation
- reinstate tests for validation and threadpool usage
- document the change in an ADR and log actions

## Testing
- `pylint app.py tests/test_app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6876e97d37a8832ba1dc6dd777979249