### PR TITLE
Clean audit log with script

### DIFF
--- a/decisions/audit_log_maintenance_adr.md
+++ b/decisions/audit_log_maintenance_adr.md
@@ -1,0 +1,11 @@
+# ADR: Maintain append-only audit log
+
+## Context
+The audit log at `logs/actions.jsonl` tracks changes to the codebase. During merges duplicate entries can appear, which makes chronological processing harder.
+
+## Decision
+We use a Python utility `scripts/cleanup_actions_log.py` to deduplicate entries and sort them by ISO 8601 timestamp. This keeps the log append-only and deterministic for parsing tools.
+
+## Links
+- https://jsonlines.org/
+- https://docs.python.org/3/library/logging.html

--- a/decisions/audit_log_maintenance_adr.md
+++ b/decisions/audit_log_maintenance_adr.md
@@ -1,10 +1,10 @@
 # ADR: Maintain append-only audit log
 
 ## Context
-The audit log at `logs/actions.jsonl` tracks changes to the codebase. During merges duplicate entries can appear, which makes chronological processing harder.
+The audit log at `logs/actions.jsonl` tracks changes to the codebase using the JSON Lines format. During merges duplicate entries can appear, which makes chronological processing harder and can break streaming parsers that expect strictly ordered records.
 
 ## Decision
-We use a Python utility `scripts/cleanup_actions_log.py` to deduplicate entries and sort them by ISO 8601 timestamp. This keeps the log append-only and deterministic for parsing tools.
+We use a Python utility `scripts/cleanup_actions_log.py` to deduplicate entries and sort them by ISO&nbsp;8601 timestamp. This keeps the log append-only and deterministic for parsing tools while adhering to the JSON Lines specification and Python logging best practices.
 
 ## Links
 - https://jsonlines.org/

--- a/logs/actions.jsonl
+++ b/logs/actions.jsonl
@@ -5,26 +5,26 @@
 {"timestamp": "2025-07-15T20:55:13Z", "action": "Add Docker-based CI workflow with README badge", "ticket_id": "task-ci-docker"}
 {"timestamp": "2025-07-15T21:06:18Z", "action": "Add module docstring to tests and ADR", "ticket_id": "task-docstring"}
 {"timestamp": "2025-07-15T21:06:40Z", "action": "Add MIT License file and update README", "ticket_id": "task-license-file"}
-{"timestamp": "2025-07-15T21:18:23.322083Z", "action": "Add .dockerignore, ADR, tests", "ticket_id": "task-dockerignore"}
 {"timestamp": "2025-07-15T21:07:16Z", "action": "Fix README CI badge link", "ticket_id": "task-update-badge"}
 {"timestamp": "2025-07-15T21:17:41Z", "action": "Reorder audit log, document log format", "ticket_id": "task-reorder-logs"}
-{"timestamp": "2025-07-15T21:06:40Z", "action": "Add MIT License file and update README", "ticket_id": "task-license-file"}
-{"timestamp": "2025-07-15T21:24:11Z", "action": "Add purge endpoint, JS handler, tests, ADR", "ticket_id": "task-purge-feature"}
+{"timestamp": "2025-07-15T21:18:23.322083Z", "action": "Add .dockerignore, ADR, tests", "ticket_id": "task-dockerignore"}
 {"timestamp": "2025-07-15T21:21:11Z", "action": "Add render helper with default context, new tests, ADR", "ticket_id": "task-default-context"}
+{"timestamp": "2025-07-15T21:24:11Z", "action": "Add purge endpoint, JS handler, tests, ADR", "ticket_id": "task-purge-feature"}
 {"timestamp": "2025-07-15T21:39:19Z", "action": "Add codebase review ADR", "ticket_id": "task-codebase-review"}
 {"timestamp": "2025-07-15T21:44:10Z", "action": "Document Docker pylint error", "ticket_id": "task-docker-pylint-error"}
-{"timestamp": "2025-07-15T22:00:51Z", "action": "Ignore data directory for SQLite database, update code and tests", "ticket_id": "task-ignore-database-directory"}
 {"timestamp": "2025-07-15T21:57:48Z", "action": "Expose purgeDatabase on window and add tests", "ticket_id": "task-inline-handler"}
+{"timestamp": "2025-07-15T22:00:51Z", "action": "Ignore data directory for SQLite database, update code and tests", "ticket_id": "task-ignore-database-directory"}
 {"timestamp": "2025-07-15T22:12:37Z", "action": "Document Docker tests exclusion causing pylint failure", "ticket_id": "task-docker-tests"}
+{"timestamp": "2025-07-15T22:26:25Z", "action": "Parameterize DB path via env var, update docs and tests", "ticket_id": "task-parameterize-db"}
+{"timestamp": "2025-07-15T22:30:41Z", "action": "Store uploads as BLOBs, update code, tests, docs, ADR", "ticket_id": "task-store-uploads-blob"}
 {"timestamp": "2025-07-15T22:39:11Z", "action": "Add Selenium browser tests and dependencies", "ticket_id": "task-frontend-selenium"}
+{"timestamp": "2025-07-15T22:47:23Z", "action": "Include tests in Docker image and update CI docs", "ticket_id": "task-docker-tests-fix"}
 {"timestamp": "2025-07-15T23:26:26Z", "action": "Wait for modal in Selenium tests", "ticket_id": "task-modal-wait"}
+{"timestamp": "2025-07-15T23:54:28Z", "action": "Enforce upload size and MIME checks, update docs and tests", "ticket_id": "task-upload-validation"}
 {"timestamp": "2025-07-15T23:55:20Z", "action": "Include tests in Docker image to fix Pylint", "ticket_id": "task-pylint-docker"}
+{"timestamp": "2025-07-15T23:57:56Z", "action": "Wrap SQLite operations in run_in_threadpool, add tests and ADR", "ticket_id": "task-threadpool"}
 {"timestamp": "2025-07-16T00:12:31Z", "action": "Fix variable name merge conflict in test", "ticket_id": "task-modal-error"}
 {"timestamp": "2025-07-16T00:13:00Z", "action": "Document merge variable fix ADR", "ticket_id": "task-modal-error"}
 {"timestamp": "2025-07-16T00:20:50Z", "action": "Wait for DB update using WebDriverWait", "ticket_id": "task-frontend-selenium"}
-{"timestamp": "2025-07-15T22:26:25Z", "action": "Parameterize DB path via env var, update docs and tests", "ticket_id": "task-parameterize-db"}
-{"timestamp": "2025-07-15T22:30:41Z", "action": "Store uploads as BLOBs, update code, tests, docs, ADR", "ticket_id": "task-store-uploads-blob"}
-{"timestamp": "2025-07-15T22:47:23Z", "action": "Include tests in Docker image and update CI docs", "ticket_id": "task-docker-tests-fix"}
-{"timestamp": "2025-07-15T23:57:56Z", "action": "Wrap SQLite operations in run_in_threadpool, add tests and ADR", "ticket_id": "task-threadpool"}
-{"timestamp": "2025-07-15T23:54:28Z", "action": "Enforce upload size and MIME checks, update docs and tests", "ticket_id": "task-upload-validation"}
 {"timestamp": "2025-07-16T03:18:32Z", "action": "Clarify AGENTS.md rules and add ADR", "ticket_id": "task-agents-improve"}
+{"timestamp": "2025-07-16T03:48:41Z", "action": "Clean audit log and add ADR", "ticket_id": "task-cleanup-log"}

--- a/logs/actions.jsonl
+++ b/logs/actions.jsonl
@@ -28,3 +28,4 @@
 {"timestamp": "2025-07-16T00:20:50Z", "action": "Wait for DB update using WebDriverWait", "ticket_id": "task-frontend-selenium"}
 {"timestamp": "2025-07-16T03:18:32Z", "action": "Clarify AGENTS.md rules and add ADR", "ticket_id": "task-agents-improve"}
 {"timestamp": "2025-07-16T03:48:41Z", "action": "Clean audit log and add ADR", "ticket_id": "task-cleanup-log"}
+{"timestamp": "2025-07-16T12:00:28Z", "action": "Refine audit log ADR", "ticket_id": "task-cleanup-log"}

--- a/scripts/cleanup_actions_log.py
+++ b/scripts/cleanup_actions_log.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Utility to deduplicate and sort the audit log."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def load_entries(path: Path) -> list[dict[str, str]]:
+    """Load JSON entries from the given path."""
+    entries: list[dict[str, str]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            entries.append(json.loads(line))
+    return entries
+
+
+def dedupe_sort(entries: list[dict[str, str]]) -> list[dict[str, str]]:
+    """Return entries deduplicated and sorted by timestamp."""
+    unique = {}
+    for entry in entries:
+        key = (entry["timestamp"], entry["action"], entry["ticket_id"])
+        unique[key] = entry
+    return sorted(unique.values(), key=lambda e: e["timestamp"])  # type: ignore[index]
+
+
+def save_entries(entries: list[dict[str, str]], path: Path) -> None:
+    """Write entries back to JSON Lines file."""
+    with path.open("w", encoding="utf-8") as handle:
+        for entry in entries:
+            line = json.dumps(
+                {
+                    "timestamp": entry["timestamp"],
+                    "action": entry["action"],
+                    "ticket_id": entry["ticket_id"],
+                }
+            )
+            handle.write(f"{line}\n")
+
+
+def cleanup(path: Path) -> None:
+    """Load, dedupe, sort, and save log entries."""
+    entries = load_entries(path)
+    entries = dedupe_sort(entries)
+    save_entries(entries, path)
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "path",
+        type=Path,
+        default=Path("logs/actions.jsonl"),
+        nargs="?",
+        help="Path to log file",
+    )
+    args = parser.parse_args()
+    cleanup(args.path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cleanup_log.py
+++ b/tests/test_cleanup_log.py
@@ -1,0 +1,26 @@
+"""Tests for cleanup_actions_log utility."""
+
+import json
+
+import scripts.cleanup_actions_log as cleanup
+
+
+def test_cleanup_removes_duplicates_and_sorts(tmp_path):
+    """Deduplicates and sorts log entries."""
+    sample = tmp_path / "actions.jsonl"
+    lines = [
+        {"timestamp": "2025-07-15T21:06:40Z", "action": "A", "ticket_id": "t"},
+        {"timestamp": "2025-07-15T20:00:00Z", "action": "B", "ticket_id": "t"},
+        {"timestamp": "2025-07-15T21:06:40Z", "action": "A", "ticket_id": "t"},
+    ]
+    with sample.open("w", encoding="utf-8") as handle:
+        for entry in lines:
+            handle.write(json.dumps(entry) + "\n")
+
+    cleanup.cleanup(sample)
+
+    entries = [json.loads(l) for l in sample.read_text().splitlines()]
+    assert entries == [
+        {"timestamp": "2025-07-15T20:00:00Z", "action": "B", "ticket_id": "t"},
+        {"timestamp": "2025-07-15T21:06:40Z", "action": "A", "ticket_id": "t"},
+    ]


### PR DESCRIPTION
## Summary
- remove duplicates and sort `logs/actions.jsonl`
- provide `scripts/cleanup_actions_log.py` utility
- document log maintenance in `audit_log_maintenance_adr.md`
- add unit test for cleanup script

## Testing
- `black scripts/cleanup_actions_log.py tests/test_cleanup_log.py`
- `pylint app.py tests scripts/cleanup_actions_log.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68771f750cb8832b80027d7d4077413b