### PR TITLE
Document SQLModel async decision

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,7 @@
 <!-- Add new tasks here using the format `- [ ] description` -->
 - [ ] Re-evaluate LangChain and LlamaIndex once custom LLM features expand
 - [x] Introduce Pydantic BaseSettings for environment configuration
-- [ ] Evaluate async database options like SQLModel or SQLAlchemy
+- [x] Evaluate async database options like SQLModel or SQLAlchemy
+- [ ] Implement SQLModel with SQLAlchemy's async extension
 - [ ] Choose an integration approach for Document AI and o4-mini
 - [ ] Review Docker ADRs for outdated steps

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -39,3 +39,4 @@ This directory stores ADRs for the project. The index below lists each file in c
 - [upload_limits_adr.md](upload_limits_adr.md)
 - [uploads_blob_storage_adr.md](uploads_blob_storage_adr.md)
 - [wait_for_db_update_adr.md](wait_for_db_update_adr.md)
+- [sqlmodel_async_extension_adr.md](sqlmodel_async_extension_adr.md)

--- a/decisions/sqlmodel_async_extension_adr.md
+++ b/decisions/sqlmodel_async_extension_adr.md
@@ -1,0 +1,13 @@
+# ADR: Adopt SQLModel with SQLAlchemy Async Extension
+
+## Context
+The project currently uses SQLite through the standard `sqlite3` library and `run_in_threadpool` to avoid blocking the event loop. The TODO list asked to evaluate asynchronous database options. We considered using SQLModel with SQLAlchemy's async extension, SQLAlchemy ORM directly with `AsyncSession`, and raw SQL drivers like `aiosqlite`.
+
+## Decision
+We will migrate the data layer to SQLModel using SQLAlchemy's `AsyncSession` support. This keeps the Pydantic-style models that SQLModel provides while leveraging fully asynchronous database operations available in SQLAlchemy 2.0.
+A follow-up task will implement the migration and update all endpoints and tests.
+
+## Links
+- https://github.com/tiangolo/sqlmodel/pull/1347
+- https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html
+- https://fastapi.tiangolo.com/advanced/async-sql-databases/

--- a/logs/actions.jsonl
+++ b/logs/actions.jsonl
@@ -38,3 +38,4 @@
 {"timestamp": "2025-07-16T16:07:51Z", "action": "Introduce Pydantic Settings", "ticket_id": "task-pydantic-settings"}
 {"timestamp": "2025-07-16T16:35:31Z", "action": "Add consolidation ADR and index", "ticket_id": "task-consolidate-index"}
 {"timestamp": "2025-07-16T16:49:01Z", "action": "Update AGENTS rules and add ADR", "ticket_id": "task-update-agents"}
+{"timestamp": "2025-07-16T17:10:37Z", "action": "Add SQLModel async ADR and update TODO", "ticket_id": "task-async-sqlmodel"}


### PR DESCRIPTION
## Summary
- record decision to use SQLModel with SQLAlchemy async extension
- note follow-up TODO item

## Testing
- `black --check .`
- `pylint app.py tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877db03dd48832b90b6ff146cbb5812