### PR TITLE
Finalize Document AI integration decision

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,5 +5,6 @@
 - [x] Introduce Pydantic BaseSettings for environment configuration
 - [x] Evaluate async database options like SQLModel or SQLAlchemy
 - [ ] Implement SQLModel with SQLAlchemy's async extension
-- [ ] Choose an integration approach for Document AI and o4-mini
+- [x] Choose an integration approach for Document AI and o4-mini
+- [ ] Prototype LangChain pipeline using Document AI and o4-mini
 - [ ] Review Docker ADRs for outdated steps

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -40,3 +40,4 @@ This directory stores ADRs for the project. The index below lists each file in c
 - [uploads_blob_storage_adr.md](uploads_blob_storage_adr.md)
 - [wait_for_db_update_adr.md](wait_for_db_update_adr.md)
 - [sqlmodel_async_extension_adr.md](sqlmodel_async_extension_adr.md)
+- [doc_ai_o4mini_langchain_decision_adr.md](doc_ai_o4mini_langchain_decision_adr.md)

--- a/decisions/doc_ai_o4mini_langchain_decision_adr.md
+++ b/decisions/doc_ai_o4mini_langchain_decision_adr.md
@@ -1,0 +1,20 @@
+# ADR: Integrate Document AI and o4-mini via LangChain community modules
+
+## Context
+An earlier ADR explored options for combining Google Document AI OCR with the
+o4-mini language model. We considered direct API calls, using LangChain
+community modules, or deploying everything serverlessly. The team prefers a
+solution that reuses existing tooling yet avoids excess complexity.
+
+## Decision
+We will integrate Google Document AI and the o4-mini LLM through LangChain's
+community-supported modules. Specifically we will use
+`GoogleDocumentAIWarehouseRetriever` to fetch OCR results and
+`LlamaCpp` to run o4-mini with the `llama-cpp-python` bindings. This keeps the
+implementation consistent with the rest of our LangChain-based pipeline while
+maintaining the flexibility to swap components if needed.
+
+## Links
+- https://cloud.google.com/document-ai/docs
+- https://python.langchain.com/docs/integrations/tools/document_ai
+- https://github.com/abetlen/llama-cpp-python

--- a/logs/actions.jsonl
+++ b/logs/actions.jsonl
@@ -39,3 +39,4 @@
 {"timestamp": "2025-07-16T16:35:31Z", "action": "Add consolidation ADR and index", "ticket_id": "task-consolidate-index"}
 {"timestamp": "2025-07-16T16:49:01Z", "action": "Update AGENTS rules and add ADR", "ticket_id": "task-update-agents"}
 {"timestamp": "2025-07-16T17:10:37Z", "action": "Add SQLModel async ADR and update TODO", "ticket_id": "task-async-sqlmodel"}
+{"timestamp": "2025-07-16T17:21:03Z", "action": "Decide on Doc AI integration via LangChain", "ticket_id": "task-doc-ai-langchain"}


### PR DESCRIPTION
## Summary
- document the choice to integrate Doc AI and o4-mini with LangChain community modules
- mark the TODO item done and add a follow-up task
- record the decision in the audit log

## Testing
- `black --check .`
- `pylint app.py tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877ddd5959c832b96a95a8297a0ff9e