### PR TITLE
Mark Docker Pylint ADR as superseded

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,4 +7,4 @@
 - [ ] Implement SQLModel with SQLAlchemy's async extension
 - [x] Choose an integration approach for Document AI and o4-mini
 - [ ] Prototype LangChain pipeline using Document AI and o4-mini
-- [ ] Review Docker ADRs for outdated steps
+- [x] Review Docker ADRs for outdated steps

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -11,7 +11,7 @@ This directory stores ADRs for the project. The index below lists each file in c
 - [database_directory_adr.md](database_directory_adr.md)
 - [docker_ci_adr.md](docker_ci_adr.md)
 - [docker_ignored_tests_adr.md](docker_ignored_tests_adr.md) — *superseded by* [include_tests_in_docker_adr.md](include_tests_in_docker_adr.md)
-- [docker_pylint_error_adr.md](docker_pylint_error_adr.md)
+- [docker_pylint_error_adr.md](docker_pylint_error_adr.md) — *superseded by* [include_tests_in_docker_adr.md](include_tests_in_docker_adr.md)
 - [dockerignore_adr.md](dockerignore_adr.md) — *superseded by* [include_tests_in_docker_adr.md](include_tests_in_docker_adr.md)
 - [env_db_path_adr.md](env_db_path_adr.md)
 - [external_parsing_adr.md](external_parsing_adr.md)
@@ -41,3 +41,4 @@ This directory stores ADRs for the project. The index below lists each file in c
 - [wait_for_db_update_adr.md](wait_for_db_update_adr.md)
 - [sqlmodel_async_extension_adr.md](sqlmodel_async_extension_adr.md)
 - [doc_ai_o4mini_langchain_decision_adr.md](doc_ai_o4mini_langchain_decision_adr.md)
+- [docker_adrs_review_adr.md](docker_adrs_review_adr.md)

--- a/decisions/docker_adrs_review_adr.md
+++ b/decisions/docker_adrs_review_adr.md
@@ -1,0 +1,11 @@
+# ADR: Docker ADRs Review
+
+## Context
+We reviewed existing Docker-related ADRs to ensure they match the current workflow. The current solution keeps tests inside the Docker build so tools like Pylint can run without PYTHONPATH tweaks. The record `docker_pylint_error_adr.md` documents an earlier workaround that is no longer needed.
+
+## Decision
+Mark `docker_pylint_error_adr.md` as superseded by `include_tests_in_docker_adr.md`. Other Docker ADRs remain accurate. The index now reflects which files are outdated.
+
+## Links
+- https://docs.docker.com/develop/dev-best-practices/#dockerignore
+- https://pylint.pycqa.org/en/latest/user_guide/run.html

--- a/decisions/docker_pylint_error_adr.md
+++ b/decisions/docker_pylint_error_adr.md
@@ -1,4 +1,6 @@
 # ADR: Pylint error when running tests in Docker
+**Status: superseded by [include_tests_in_docker_adr.md](include_tests_in_docker_adr.md)**
+
 
 ## Context
 Running the Docker command `pylint app.py tests` failed with `No module named tests` because the container's working directory did not include the Python path for the `tests` package. Pylint expects modules to be importable to analyze them.

--- a/logs/actions.jsonl
+++ b/logs/actions.jsonl
@@ -40,3 +40,4 @@
 {"timestamp": "2025-07-16T16:49:01Z", "action": "Update AGENTS rules and add ADR", "ticket_id": "task-update-agents"}
 {"timestamp": "2025-07-16T17:10:37Z", "action": "Add SQLModel async ADR and update TODO", "ticket_id": "task-async-sqlmodel"}
 {"timestamp": "2025-07-16T17:21:03Z", "action": "Decide on Doc AI integration via LangChain", "ticket_id": "task-doc-ai-langchain"}
+{"timestamp": "2025-07-16T17:29:13Z", "action": "Mark outdated Docker ADR as superseded and add review ADR", "ticket_id": "task-docker-adrs"}

--- a/tests/test_decisions_readme.py
+++ b/tests/test_decisions_readme.py
@@ -1,0 +1,24 @@
+"""Tests for decisions README updates."""
+
+from pathlib import Path
+
+
+def test_docker_pylint_error_marked_superseded():
+    """The README should note that docker_pylint_error_adr is superseded."""
+    readme = Path(__file__).resolve().parents[1] / "decisions" / "README.md"
+    content = readme.read_text()
+    expected = (
+        "[docker_pylint_error_adr.md](docker_pylint_error_adr.md)"
+        " — *superseded by* [include_tests_in_docker_adr.md](include_tests_in_docker_adr.md)"
+    )
+    assert expected in content
+
+
+def test_docker_pylint_adr_contains_note():
+    """ADR file itself should contain superseded status note."""
+    adr_path = (
+        Path(__file__).resolve().parents[1] / "decisions" / "docker_pylint_error_adr.md"
+    )
+    content = adr_path.read_text()
+    assert "superseded" in content
+    assert "include_tests_in_docker_adr.md" in content


### PR DESCRIPTION
## Summary
- note that `docker_pylint_error_adr` is superseded
- index the new ADR and entry in `README`
- add tests covering the superseded note
- document the review in `docker_adrs_review_adr.md`
- log the update and mark TODO complete

## Testing
- `black --check .`
- `pylint app.py tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877e0028cb4832b9a611b6cbb23f0b4