### PR TITLE
Add ADR on o4-mini LangChain usage

### DIFF
--- a/decisions/README.md
+++ b/decisions/README.md
@@ -44,3 +44,4 @@ This directory stores ADRs for the project. The index below lists each file in c
 - [docker_adrs_review_adr.md](docker_adrs_review_adr.md)
 - [async_pipeline_adr.md](async_pipeline_adr.md)
 - [stubbed_pipeline_adr.md](stubbed_pipeline_adr.md)
+- [o4mini_langchain_usage_adr.md](o4mini_langchain_usage_adr.md)

--- a/decisions/o4mini_langchain_usage_adr.md
+++ b/decisions/o4mini_langchain_usage_adr.md
@@ -1,0 +1,20 @@
+# ADR: Using o4-mini-2025-04-16 with LangChain
+
+## Context
+OpenAI released o4-mini as a fast reasoning model optimized for coding and visual tasks. The [model page](https://platform.openai.com/docs/models/o4-mini) describes it as "our latest small o-series model" with a 200k context window and a snapshot named `o4-mini-2025-04-16`. The [April 16, 2025 release notes](https://platform.openai.com/docs/changelog) introduced both o3 and o4-mini reasoning models. The official [blog post](https://openai.com/index/introducing-o3-and-o4-mini/) highlights their ability to combine tools like web search and file analysis for more complex answers.
+
+## Decision
+Developers can call the model through LangChain's `ChatOpenAI` interface by specifying the snapshot name.
+
+```python
+from langchain_openai import ChatOpenAI
+
+llm = ChatOpenAI(model="o4-mini-2025-04-16")
+response = llm.invoke("Explain Newton's third law in simple terms")
+print(response)
+```
+
+## Links
+- <https://platform.openai.com/docs/models/o4-mini>
+- <https://platform.openai.com/docs/changelog>
+- <https://openai.com/index/introducing-o3-and-o4-mini/>

--- a/logs/actions.jsonl
+++ b/logs/actions.jsonl
@@ -43,3 +43,4 @@
 {"timestamp": "2025-07-16T17:29:13Z", "action": "Mark outdated Docker ADR as superseded and add review ADR", "ticket_id": "task-docker-adrs"}
 {"timestamp": "2025-07-16T18:09:58Z", "action": "Add async pipeline with background tasks", "ticket_id": "task-langchain-async"}
 {"timestamp": "2025-07-16T18:33:27Z", "action": "Remove llama-cpp and add cmake and g++", "ticket_id": "task-build-fix"}
+{"timestamp": "2025-07-16T19:01:50Z", "action": "Add o4-mini research ADR", "ticket_id": "task-o4-mini-langchain"}


### PR DESCRIPTION
## Summary
- add ADR summarizing how to use `o4-mini-2025-04-16` with LangChain
- index the ADR in decisions README
- log the action

## Testing
- `black --check .`
- `pylint app.py tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877f4781e3c832bab7c97ee39d7d618