### PR TITLE
Add structlog ADR

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9,3 +9,4 @@
 - [x] Prototype LangChain pipeline using Document AI and o4-mini
 - [ ] Evaluate Celery for distributed task processing
 - [x] Review Docker ADRs for outdated steps
+- [ ] Implement structured JSON logging as outlined in structured_logging_structlog_adr.md

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -44,3 +44,4 @@ This directory stores ADRs for the project. The index below lists each file in c
 - [docker_adrs_review_adr.md](docker_adrs_review_adr.md)
 - [async_pipeline_adr.md](async_pipeline_adr.md)
 - [stubbed_pipeline_adr.md](stubbed_pipeline_adr.md)
+- [structured_logging_structlog_adr.md](structured_logging_structlog_adr.md)

--- a/decisions/structured_logging_structlog_adr.md
+++ b/decisions/structured_logging_structlog_adr.md
@@ -1,0 +1,16 @@
+# ADR: Adopt structlog for JSON logging
+
+## Context
+We currently use Python's built-in logging for miscellaneous messages but lack a consistent structured format. Structured logs facilitate easier filtering and analysis in production. structlog is a well-maintained library focused on structured logging and integrates with the standard logging module.
+
+## Decision
+We will adopt the `structlog` library to produce JSON-formatted logs across the application. This allows adding contextual data to log events and outputs JSON for ingestion by log processors.
+
+## Consequences
+- Adds `structlog` as a project dependency.
+- Requires initializing structlog early in application startup.
+- Existing log statements should be migrated to use the new API.
+
+## Links
+- https://www.structlog.org/en/stable/why.html
+- https://www.structlog.org/en/stable/getting-started.html

--- a/logs/actions.jsonl
+++ b/logs/actions.jsonl
@@ -43,3 +43,4 @@
 {"timestamp": "2025-07-16T17:29:13Z", "action": "Mark outdated Docker ADR as superseded and add review ADR", "ticket_id": "task-docker-adrs"}
 {"timestamp": "2025-07-16T18:09:58Z", "action": "Add async pipeline with background tasks", "ticket_id": "task-langchain-async"}
 {"timestamp": "2025-07-16T18:33:27Z", "action": "Remove llama-cpp and add cmake and g++", "ticket_id": "task-build-fix"}
+{"timestamp": "2025-07-16T19:14:34Z", "action": "Add structured logging ADR and tests", "ticket_id": "task-structlog-adr"}

--- a/requirements.in
+++ b/requirements.in
@@ -14,3 +14,4 @@ webdriver-manager
 langchain
 langchain-community
 google-cloud-documentai
+structlog

--- a/requirements.txt
+++ b/requirements.txt
@@ -239,6 +239,8 @@ sqlalchemy==2.0.41
     #   langchain-community
 starlette==0.47.1
     # via fastapi
+structlog==25.4.0
+    # via -r requirements.in
 tenacity==9.1.2
     # via
     #   langchain-community

--- a/tests/test_decisions_readme.py
+++ b/tests/test_decisions_readme.py
@@ -22,3 +22,21 @@ def test_docker_pylint_adr_contains_note():
     content = adr_path.read_text()
     assert "superseded" in content
     assert "include_tests_in_docker_adr.md" in content
+
+
+def test_structured_logging_adr_indexed():
+    """README should list the structured logging ADR."""
+    readme = Path(__file__).resolve().parents[1] / "decisions" / "README.md"
+    content = readme.read_text()
+    assert "structured_logging_structlog_adr.md" in content
+
+
+def test_structured_logging_adr_mentions_structlog():
+    """ADR file should mention structlog."""
+    adr_path = (
+        Path(__file__).resolve().parents[1]
+        / "decisions"
+        / "structured_logging_structlog_adr.md"
+    )
+    content = adr_path.read_text().lower()
+    assert "structlog" in content


### PR DESCRIPTION
## Summary
- document decision to adopt structlog for JSON logging
- index ADR in decisions README
- add TODO item for implementing structured logging
- add unit tests verifying ADR presence
- pin structlog dependency
- log action in audit log

## Testing
- `black --check .`
- `pylint app.py tests`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6877f8415298832bab581be3f8eea9f3