### PR TITLE
Implement OCR parsing prompt

### DIFF
--- a/decisions/general_ocr_custom_parsing_adr.md
+++ b/decisions/general_ocr_custom_parsing_adr.md
@@ -1,0 +1,11 @@
+# ADR: General OCR with custom LangChain parsing
+
+## Context
+We chose Option 2 from the planning discussion: use Document AI's general OCR processor to extract raw text, then parse financial fields via a custom prompt handled by LangChain and the o4-mini model.
+
+## Decision
+Implement a prompt that asks the LLM to extract invoice number, date, and total amount from the OCR text. The `AsyncPipeline.run` method now builds this prompt before passing it to the LLM.
+
+## Links
+- https://cloud.google.com/document-ai/docs/overview
+- https://python.langchain.com/docs/modules/model_io/prompts/prompt_templates/

--- a/logs/actions.jsonl
+++ b/logs/actions.jsonl
@@ -48,3 +48,4 @@
 {"timestamp": "2025-07-16T20:00:26Z", "action": "Implement LangChain Document AI pipeline with ADR", "ticket_id": "task-doc-ai-pipeline"}
 {"timestamp": "2025-07-16T20:23:54Z", "action": "Add Celery worker microservice ADR", "ticket_id": "task-celery-microservice"}
 {"timestamp": "2025-07-16T20:48:38Z", "action": "Implement Celery worker microservice", "ticket_id": "task-celery-worker"}
+{"timestamp": "2025-07-16T21:31:48Z", "action": "Add OCR parsing prompt", "ticket_id": "task-option2"}

--- a/pipeline.py
+++ b/pipeline.py
@@ -45,7 +45,11 @@ class AsyncPipeline:
     async def run(self, data: bytes) -> str:
         """Run OCR then LLM on the given file bytes."""
         text = await self.ocr.extract(data)
-        return await self.llm.generate(text)
+        prompt = (
+            "Extract the invoice number, date, and total from this text as JSON.\n"
+            f"{text}"
+        )
+        return await self.llm.generate(prompt)
 
 
 class StubOCRClient:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -16,7 +16,11 @@ def test_pipeline_stub_run():
     """Pipeline should combine stub components."""
     pl = AsyncPipeline(StubOCRClient(), StubLLMClient())
     result = asyncio.run(pl.run(b"data"))
-    assert result == "processed: stub text"
+    expected_prompt = (
+        "Extract the invoice number, date, and total from this text as JSON.\n"
+        "stub text"
+    )
+    assert result == f"processed: {expected_prompt}"
 
 
 def test_process_endpoint(tmp_path, monkeypatch):
@@ -103,4 +107,8 @@ def test_create_langchain_pipeline(monkeypatch):
 
     pipeline = pl.create_langchain_pipeline()
     result = asyncio.run(pipeline.run(b"data"))
-    assert result == "ocr text processed"
+    expected_prompt = (
+        "Extract the invoice number, date, and total from this text as JSON.\n"
+        "ocr text"
+    )
+    assert result == f"{expected_prompt} processed"


### PR DESCRIPTION
## Summary
- add prompt to parse invoice fields with o4-mini
- test pipeline output using new prompt
- document approach in new ADR
- log the change

## Testing
- `pytest -q`
- `black --check .`


------
https://chatgpt.com/codex/tasks/task_e_687812445290832bb90ea5098c0b9812