### PR TITLE
Add PipelineConfig configuration class with ADR

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ DOC_AI_PROCESSOR_ID=<processor-id>
 O4MINI_MODEL_PATH=/path/to/o4-mini.gguf
 ```
 
-Then call `pipeline.create_langchain_pipeline()` in place of the stubs.
+Then call `pipeline.create_langchain_pipeline(PipelineConfig())` in place of the stubs.
+`PipelineConfig` (from `config.py`) reads these variables from the environment using
+Pydantic's `BaseSettings`.
 
 ### Celery worker
 

--- a/TODO.md
+++ b/TODO.md
@@ -12,4 +12,5 @@
 - [x] Review Docker ADRs for outdated steps
 - [ ] Implement structured JSON logging as outlined in structured_logging_structlog_adr.md
 - [ ] Configure env variables for production pipeline per financial_extraction_pipeline_adr.md
+- [ ] Update production configuration to use PipelineConfig per pipeline_config_adr.md
 - [x] Implement Celery worker microservice

--- a/config.py
+++ b/config.py
@@ -14,3 +14,12 @@ class Settings(BaseSettings):
 
 
 settings = Settings()
+
+
+class PipelineConfig(BaseSettings):
+    """Settings for the Document AI and o4-mini pipeline."""
+
+    doc_ai_project_id: str
+    doc_ai_location: str = "us"
+    doc_ai_processor_id: str
+    o4mini_model_path: str

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -49,3 +49,4 @@ This directory stores ADRs for the project. The index below lists each file in c
 - [financial_extraction_pipeline_adr.md](financial_extraction_pipeline_adr.md)
 - [celery_worker_microservice_adr.md](celery_worker_microservice_adr.md)
 - [celery_worker_implementation_adr.md](celery_worker_implementation_adr.md)
+- [pipeline_config_adr.md](pipeline_config_adr.md)

--- a/decisions/pipeline_config_adr.md
+++ b/decisions/pipeline_config_adr.md
@@ -1,0 +1,25 @@
+# ADR: Introduce PipelineConfig for LangChain pipeline
+
+## Context
+The LangChain pipeline currently reads environment variables directly in
+`create_langchain_pipeline`. This makes testing harder and scatters
+configuration logic. Pydantic's `BaseSettings` offers a structured way to
+validate environment variables. Google Document AI and the `llama-cpp-python`
+model require several variables to be set correctly.
+
+## Decision
+Add a `PipelineConfig` class derived from `BaseSettings` in `config.py`. It
+defines `doc_ai_project_id`, `doc_ai_location`, `doc_ai_processor_id`, and
+`o4mini_model_path`. The `create_langchain_pipeline` function now accepts an
+optional `PipelineConfig` instance and defaults to loading from the
+environment. Worker code passes in `PipelineConfig()` when building the real
+pipeline.
+
+## Consequences
+Centralizes pipeline configuration and simplifies testing by allowing explicit
+config objects. Environment variables are still supported via Pydantic.
+
+## Links
+- https://docs.pydantic.dev/latest/usage/settings/
+- https://cloud.google.com/document-ai/docs
+- https://github.com/abetlen/llama-cpp-python

--- a/logs/actions.jsonl
+++ b/logs/actions.jsonl
@@ -49,3 +49,4 @@
 {"timestamp": "2025-07-16T20:23:54Z", "action": "Add Celery worker microservice ADR", "ticket_id": "task-celery-microservice"}
 {"timestamp": "2025-07-16T20:48:38Z", "action": "Implement Celery worker microservice", "ticket_id": "task-celery-worker"}
 {"timestamp": "2025-07-16T21:31:48Z", "action": "Add OCR parsing prompt", "ticket_id": "task-option2"}
+{"timestamp": "2025-07-16T21:54:42Z", "action": "Introduce PipelineConfig class and ADR", "ticket_id": "task-pipeline-config"}

--- a/pipeline.py
+++ b/pipeline.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 # pylint: disable=too-few-public-methods,unused-argument, import-outside-toplevel, broad-exception-caught, useless-import-alias, invalid-name
 from typing import Protocol
 
+from config import PipelineConfig
+
 try:  # optional import for patching in tests
     from google.cloud import (
         documentai as DOCUMENTAI,
@@ -107,17 +109,14 @@ class O4MiniClient:
         return await loop.run_in_executor(None, self._llm.invoke, prompt)
 
 
-def create_langchain_pipeline() -> AsyncPipeline:
+def create_langchain_pipeline(config: PipelineConfig | None = None) -> AsyncPipeline:
     """Construct a pipeline using Document AI and o4-mini via LangChain."""
-    import os
+    cfg = config or PipelineConfig()
 
-    project = os.environ.get("DOC_AI_PROJECT_ID")
-    location = os.environ.get("DOC_AI_LOCATION", "us")
-    processor = os.environ.get("DOC_AI_PROCESSOR_ID")
-    model_path = os.environ.get("O4MINI_MODEL_PATH")
-    if not (project and processor and model_path):
-        raise RuntimeError("Document AI and o4-mini configuration missing")
-
-    ocr_client = DocumentAIClient(project, location, processor)
-    llm_client = O4MiniClient(model_path)
+    ocr_client = DocumentAIClient(
+        cfg.doc_ai_project_id,
+        cfg.doc_ai_location,
+        cfg.doc_ai_processor_id,
+    )
+    llm_client = O4MiniClient(cfg.o4mini_model_path)
     return AsyncPipeline(ocr_client, llm_client)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -64,10 +64,12 @@ def test_create_langchain_pipeline(monkeypatch):
     """create_langchain_pipeline should use env vars to configure clients."""
     import pipeline as pl
 
-    monkeypatch.setenv("DOC_AI_PROJECT_ID", "proj")
-    monkeypatch.setenv("DOC_AI_LOCATION", "us")
-    monkeypatch.setenv("DOC_AI_PROCESSOR_ID", "pid")
-    monkeypatch.setenv("O4MINI_MODEL_PATH", "/model.bin")
+    cfg = pl.PipelineConfig(
+        doc_ai_project_id="proj",
+        doc_ai_location="us",
+        doc_ai_processor_id="pid",
+        o4mini_model_path="/model.bin",
+    )
 
     class FakeDocClient:
         def processor_path(self, p, l, pr):
@@ -105,7 +107,7 @@ def test_create_langchain_pipeline(monkeypatch):
     )
     monkeypatch.setattr(pl, "LLAMACPP", FakeLlama)
 
-    pipeline = pl.create_langchain_pipeline()
+    pipeline = pl.create_langchain_pipeline(cfg)
     result = asyncio.run(pipeline.run(b"data"))
     expected_prompt = (
         "Extract the invoice number, date, and total from this text as JSON.\n"

--- a/worker.py
+++ b/worker.py
@@ -9,6 +9,7 @@ from pipeline import (
     StubLLMClient,
     create_langchain_pipeline,
 )
+from config import PipelineConfig
 
 celery_app = Celery(
     "smartbooks",
@@ -16,7 +17,7 @@ celery_app = Celery(
 )
 
 if os.environ.get("USE_REAL_PIPELINE") == "1":
-    pipeline = create_langchain_pipeline()
+    pipeline = create_langchain_pipeline(PipelineConfig())
 else:
     pipeline = AsyncPipeline(StubOCRClient(), StubLLMClient())
 


### PR DESCRIPTION
## Summary
- add new `PipelineConfig` Pydantic class for Doc AI and o4-mini variables
- refactor `create_langchain_pipeline` and worker to use it
- document usage in `README`
- record decision in `pipeline_config_adr`
- add follow-up task in `TODO.md`
- log the change in `actions.jsonl`

## Testing
- `black --check config.py pipeline.py worker.py tests/test_pipeline.py`
- `pylint app.py tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68781c7c02a4832b81e8fc0211cf1de4